### PR TITLE
PVR list item icons

### DIFF
--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -362,13 +362,12 @@
     </include>
 
     <include name="Object_PVR_Info">
-        <param name="artwork" default="Window(Home).Property(SkinHelper.ListItem.Art.Fanart)" />
         <definition>
             <control type="group">
                 <include>Animation_Home_Textbar_Slideover_Library</include>
                 <include>Animation_Right</include>
                 <control type="group">
-                    <visible>!String.IsEmpty($PARAM[artwork]) + !String.StartsWith(Control.GetLabel(9123),Default)</visible>
+                    <visible>!String.IsEmpty(ListItem.Icon)</visible>
                     <include>Animation_FadeIn</include>
                     <bottom>605</bottom>
                     <top>196</top>
@@ -378,11 +377,11 @@
                         <include>Defs_Shadow_Opaque</include>
                         <fadetime>100</fadetime>
                         <aspectratio>scale</aspectratio>
-                        <texture>$INFO[$PARAM[artwork]]</texture>
+                        <texture>$INFO[ListItem.Icon]</texture>
                     </control>
                 </control>
                 <control type="grouplist">
-                    <visible>!String.IsEmpty($PARAM[artwork]) + !String.StartsWith(Control.GetLabel(9123),Default)</visible>
+                    <visible>!String.IsEmpty(ListItem.Icon)</visible>
                     <bottom>600</bottom>
                     <top>176</top>
                     <left>129</left>
@@ -393,7 +392,7 @@
                     <include>Object_PVR_Info_Content</include>
                 </control>
                 <control type="grouplist">
-                    <visible>String.IsEmpty($PARAM[artwork]) | String.StartsWith(Control.GetLabel(9123),Default)</visible>
+                    <visible>String.IsEmpty(ListItem.Icon)</visible>
                     <bottom>600</bottom>
                     <top>176</top>
                     <left>129</left>

--- a/1080i/MyPVRRecordings.xml
+++ b/1080i/MyPVRRecordings.xml
@@ -11,9 +11,7 @@
 
         <control type="group">
             <right>80</right>
-            <include content="Object_PVR_Info">
-                <param name="artwork" value="Container(50).ListItem.Icon" />
-            </include>
+            <include>Object_PVR_Info</include>
         </control>
 
         <include>Topbar</include>


### PR DESCRIPTION
This is working for me, but the only issue is that when there's no icon art I'm getting the default images (like a folder icon, or the "reload" back to parent folder icon) in the art container.

What's sort of strange is that `$PARAM[artwork]` was just not working at all. I could pass whatever I wanted in there and it wouldn't function (so in `<texture>` `$INFO[$PARAM[artwork]]` wouldn't work when artwork was `ListItem.Icon`, but `$INFO[ListItem.Icon]` *would* work).

I'm not sure what `!String.StartsWith(Control.GetLabel(9123),Default)` is, but I had to remove it for anything to work.